### PR TITLE
fix single command execution bug, cause by not set execvp's first par…

### DIFF
--- a/simple-c-shell.c
+++ b/simple-c-shell.c
@@ -559,6 +559,7 @@ int commandHandler(char * args[]){
 		}
 		// We launch the program with our method, indicating if we
 		// want background execution or not
+		args_aux[i] = NULL;
 		launchProg(args_aux,background);
 		
 		/**


### PR DESCRIPTION
…ameter end with NULL